### PR TITLE
Harden SigningCertURL regex

### DIFF
--- a/sns.py
+++ b/sns.py
@@ -31,7 +31,7 @@ def is_message_signature_valid(msg):
         raise Exception('Wrong signature version')
 
     signing_url = msg[u'SigningCertURL']
-    prog = regex_compile(r'^https.*amazonaws\.com\/.*$', IGNORECASE)
+    prog = regex_compile(r'^https://sns\.[-a-z0-9]+\.amazonaws\.com/.*$', IGNORECASE)
     if not prog.match(signing_url):
         raise Exception("Cert is not hosted at AWS URL (https): %s",
                         signing_url)


### PR DESCRIPTION
Thanks for the SNS signature code, has been a very helpful reference!

Found a bug in the SigningCertURL check - the regex confirms the URL exists on amazonaws.com, but there's a few ways that non-Amazon entities can generate these URLs. For example: https://s3.amazonaws.com/not-sns-test/fake-cert.pem

The above URL passes the previous check:

``` python
>>> from re import compile as regex_compile, IGNORECASE
>>> 
>>> signing_url = "https://s3.amazonaws.com/not-sns-test/fake-cert.pem"
>>> 
>>> prog = regex_compile(r'^https.*amazonaws\.com\/.*$', IGNORECASE)
>>> if not prog.match(signing_url):
...     raise Exception("Cert is not hosted at AWS URL (https): %s",
...                     signing_url)
```
